### PR TITLE
Add PrfExpand for ORCHARD_DERIVED_ISSUE_RHO

### DIFF
--- a/src/prf_expand.rs
+++ b/src/prf_expand.rs
@@ -102,6 +102,11 @@ impl PrfExpand<([u8; 32], [u8; 32])> {
     pub const ORCHARD_DK_OVK: Self = Self::new(0x82);
     pub const ORCHARD_RIVK_INTERNAL: Self = Self::new(0x83);
 }
+
+impl PrfExpand<([u8; 4], [u8; 4])> {
+    pub const ORCHARD_DERIVED_ISSUE_RHO: Self = Self::new(0x84);
+}
+
 with_inputs!(a, A, b, B);
 
 impl PrfExpand<([u8; 96], [u8; 32], [u8; 4])> {


### PR DESCRIPTION
Add `PrfExpand` for `ORCHARD_DERIVED_ISSUE_RHO`, as discussed in the OrchardZSA review: https://github.com/zcash/orchard/pull/471#discussion_r2543127484

~~Consider adjusting the base branch to be compatible with the Orchard feature branch structure: https://github.com/zcash/orchard/tree/ltf/zsa (`ltf/zsa`)~~ not needed, as commented by str4d